### PR TITLE
Generate Chess Notation after each Move (and fix board layout)

### DIFF
--- a/Chess/src/chess/Cell.java
+++ b/Chess/src/chess/Cell.java
@@ -30,7 +30,7 @@ public class Cell extends JPanel implements Cloneable {
 
         setLayout(new BorderLayout());
 
-        if ((x + y) % 2 == 0)
+        if ((x + y) % 2 == 1)
             setBackground(new Color(113, 198, 113));
 
         else
@@ -46,7 +46,7 @@ public class Cell extends JPanel implements Cloneable {
         this.x = cell.x;
         this.y = cell.y;
         setLayout(new BorderLayout());
-        if ((x + y) % 2 == 0)
+        if ((x + y) % 2 == 1)
             setBackground(new Color(113, 198, 113));
         else
             setBackground(Color.white);
@@ -123,7 +123,7 @@ public class Cell extends JPanel implements Cloneable {
     public void removecheck() // Function to deselect check
     {
         this.setBorder(null);
-        if ((x + y) % 2 == 0)
+        if ((x + y) % 2 == 1)
             setBackground(new Color(113, 198, 113));
         else
             setBackground(Color.white);

--- a/Chess/src/chess/Main.java
+++ b/Chess/src/chess/Main.java
@@ -218,13 +218,13 @@ public class Main extends JFrame implements MouseListener {
                 else if (i == 7 && j == 5)
                     P = whiteBishops.get(1);
                 else if (i == 0 && j == 3)
-                    P = blackKing;
-                else if (i == 0 && j == 4)
                     P = blackQueens.get(0);
+                else if (i == 0 && j == 4)
+                    P = blackKing;
                 else if (i == 7 && j == 3)
-                    P = whiteKing;
-                else if (i == 7 && j == 4)
                     P = whiteQueens.get(0);
+                else if (i == 7 && j == 4)
+                    P = whiteKing;
                 else if (i == 1)
                     P = blackPawns.get(j);
                 else if (i == 6)
@@ -609,6 +609,9 @@ public class Main extends JFrame implements MouseListener {
             } else if (c.getpiece() == null || previous.getpiece().getcolor() != c.getpiece().getcolor()) {
                 // This increments move count for rook and king when moved
             	if (c.ispossibledestination()) {
+            	    
+            	    System.out.println(generateNotation(previous.x, previous.y, c.x, c.y, null));
+            	    
                 	if (previous.getpiece() instanceof Rook || previous.getpiece() instanceof King) {
                     	previous.getpiece().incrementMoveCount();
                     }
@@ -942,10 +945,10 @@ public class Main extends JFrame implements MouseListener {
                 new Bishop("WB02", "White_Bishop.png", 0, 7, 5));
         blackBishops = Arrays.asList(new Bishop("BB01", "Black_Bishop.png", 1, 0, 2),
                 new Bishop("BB02", "Black_Bishop.png", 1, 0, 5));
-        whiteQueens = Arrays.asList(new Queen("WQ", "White_Queen.png", 0, 7, 4));
-        blackQueens = Arrays.asList(new Queen("BQ", "Black_Queen.png", 1, 0, 4));
-        whiteKing = new King("WK", "White_King.png", 0, 7, 3);
-        blackKing = new King("BK", "Black_King.png", 1, 0, 3);
+        whiteQueens = Arrays.asList(new Queen("WQ", "White_Queen.png", 0, 7, 3));
+        blackQueens = Arrays.asList(new Queen("BQ", "Black_Queen.png", 1, 0, 3));
+        whiteKing = new King("WK", "White_King.png", 0, 7, 4);
+        blackKing = new King("BK", "Black_King.png", 1, 0, 4);
         whitePawns = new ArrayList<Pawn>();
         for (int i = 0; i < 8; i++) {
             whitePawns.add(new Pawn("WP0" + (i + 1), "White_Pawn.png", 0, 6, i));
@@ -962,5 +965,20 @@ public class Main extends JFrame implements MouseListener {
 
     private void increaseTrivialMoveCounter(){
         trivialMoveCounter++;
+    }
+    
+    private String generateNotation(int fromX, int fromY, int toX, int toY, Character promo) {
+        StringBuilder sb = new StringBuilder();
+        sb.append((char)('a' + fromY));
+        sb.append(8 - fromX);
+        
+        sb.append((char)('a' + toY));
+        sb.append(8 - toX);
+        
+        if (promo != null) {
+            sb.append(Character.toLowerCase(promo.charValue()));
+        }
+        
+        return sb.toString();
     }
 }

--- a/Chess/src/pieces/King.java
+++ b/Chess/src/pieces/King.java
@@ -31,14 +31,14 @@ public class King extends Piece {
         possiblemoves = getCandidateMoves(state);
         
         if (this.getMoveCount() == 0 && !isindanger(state)) {
-        	Piece rightPiece = state[x][y+4].getpiece();
-        	Piece leftPiece = state[x][y-3].getpiece();
+        	Piece rightPiece = state[x][y+3].getpiece();
+        	Piece leftPiece = state[x][y-4].getpiece();
         	
         	// Does checks for queen side castle
         	if (rightPiece instanceof Rook && rightPiece.getcolor() == this.getcolor()) {
         		castle = true;
         		if (rightPiece.getMoveCount() == 0) {
-        			for (int i = y+1; i < y+4; i++) {
+        			for (int i = y+1; i < y+3; i++) {
         				if (castle && state[x][i].getpiece() != null) {
         					castle = false;
         				}
@@ -57,7 +57,7 @@ public class King extends Piece {
         	if (leftPiece instanceof Rook && leftPiece.getcolor() == this.getcolor()) {
         		castle = true;
         		if (leftPiece.getMoveCount() == 0) {
-        			for (int i = y-1; i > y-3; i--) {
+        			for (int i = y-1; i > y-4; i--) {
         				if (castle && state[x][i].getpiece() != null) {
         					castle = false;
         				}


### PR DESCRIPTION
Chess Notation (supported by UCI protocol) is now generated after each move. A function can be called with the x and y values of the previous and c cells to generate the string. There is also an additional parameter for a Character for the case of promotion.

The board layout has also been fixed, inverting the colors of the grid and swapping the positions of the King and Queen. Castling and piece initialization had to be tweaked as part of the change.